### PR TITLE
Allow repeated flags for map slices

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -294,7 +294,15 @@ func convert(val string, retval reflect.Value, options multiTag) error {
 			retval.Set(reflect.MakeMap(tp))
 		}
 
-		retval.SetMapIndex(reflect.Indirect(keyval), reflect.Indirect(valueval))
+		k := reflect.Indirect(keyval)
+		v := reflect.Indirect(valueval)
+		// Append if our values are slices (similarly to how we append to a slice on its own)
+		if valuetp.Kind() == reflect.Slice {
+			if existing := retval.MapIndex(k); existing.IsValid() {
+				v = reflect.AppendSlice(existing, v)
+			}
+		}
+		retval.SetMapIndex(k, v)
 	case reflect.Ptr:
 		if retval.IsNil() {
 			retval.Set(reflect.New(retval.Type().Elem()))

--- a/parser_test.go
+++ b/parser_test.go
@@ -680,3 +680,17 @@ func TestCommandHandler(t *testing.T) {
 
 	assertStringArray(t, executedArgs, []string{"arg1", "arg2"})
 }
+
+func TestMapOfSlices(t *testing.T) {
+	var opts = struct {
+		M map[string][]string `short:"m"`
+	}{}
+
+	parser := NewParser(&opts, Default&^PrintErrors)
+	_, err := parser.ParseArgs([]string{"cmd", "-m", "a:b", "-m", "a:c", "-m", "d:e"})
+	if err != nil {
+		t.Fatalf("Unexpected parse error: %s", err)
+	}
+	assertStringArray(t, opts.M["a"], []string{"b", "c"})
+	assertStringArray(t, opts.M["d"], []string{"e"})
+}


### PR DESCRIPTION
i.e. `-m a:b -m a:c` produces `{"a": ["b", "c"]}` in the same way that `-s b -s c` produces `["b", "c"]` for a slice field.