### PR TITLE
Allow setting a default number of columns if it can't be determined programmatically.

### DIFF
--- a/help.go
+++ b/help.go
@@ -66,7 +66,10 @@ func (p *Parser) getAlignmentInfo() alignmentInfo {
 	}
 
 	if ret.terminalColumns <= 0 {
-		ret.terminalColumns = 80
+		ret.terminalColumns = p.DefaultColumns
+		if p.DefaultColumns == 0 {
+			ret.terminalColumns = 80
+		}
 	}
 
 	var prevcmd *Command

--- a/parser.go
+++ b/parser.go
@@ -60,6 +60,10 @@ type Parser struct {
 	// of an unknown flag or a help flag to print additional information
 	PrintAdditionalUsageInfo func(wr io.Writer)
 
+	// DefaultColumns is the default number of columns we wrap messages at if the
+	// terminal size cannot be programmatically determined.
+	DefaultColumns int
+
 	internalError error
 }
 

--- a/termsize.go
+++ b/termsize.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9 && !appengine && !wasm
 // +build !windows,!plan9,!appengine,!wasm
 
 package flags
@@ -9,7 +10,7 @@ import (
 func getTerminalColumns() int {
 	ws, err := unix.IoctlGetWinsize(0, unix.TIOCGWINSZ)
 	if err != nil {
-		return 80
+		return 0
 	}
 	return int(ws.Col)
 }

--- a/termsize_nosysioctl.go
+++ b/termsize_nosysioctl.go
@@ -1,7 +1,8 @@
+//go:build plan9 || appengine || wasm
 // +build plan9 appengine wasm
 
 package flags
 
 func getTerminalColumns() int {
-	return 80
+	return 0
 }

--- a/termsize_windows.go
+++ b/termsize_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package flags
@@ -65,7 +66,7 @@ func GetConsoleScreenBufferInfo(handle uintptr) (*CONSOLE_SCREEN_BUFFER_INFO, er
 }
 
 func getTerminalColumns() int {
-	defaultWidth := 80
+	defaultWidth := 0
 
 	stdoutHandle, err := getStdHandle(syscall.STD_OUTPUT_HANDLE)
 	if err != nil {


### PR DESCRIPTION
I've got some internal tests that produce very hard to read output because some of the text wraps over very few columns.
I'd like to be able to force it to say 120 cols which would make it a lot more readable.