### PR TITLE
Fix issue where errors are not returned on second parse attempt

### DIFF
--- a/option.go
+++ b/option.go
@@ -329,6 +329,7 @@ func (option *Option) clearDefault() error {
 		for _, d := range usedDefault {
 			err := option.set(&d)
 			if err != nil {
+				option.preventDefault = false
 				return err
 			}
 			option.isSetDefault = true

--- a/parser_test.go
+++ b/parser_test.go
@@ -381,6 +381,35 @@ func TestEnvDefaults(t *testing.T) {
 	}
 }
 
+func TestReturnsErrorForInvalidEnvVarsOnAllParseAttempts(t *testing.T) {
+	oldEnv := EnvSnapshot()
+	defer oldEnv.Restore()
+
+	var opts envDefaultOptions
+	os.Setenv("TEST_T", "invalid")
+
+	parser := NewParser(&opts, None)
+
+	// Call ParseArgs and verify that the error is returned
+	_, err := parser.ParseArgs(nil)
+	if err == nil {
+		t.Fatal("parser did not return error for invalid env var on first call")
+	}
+	if !strings.Contains(err.Error(), "invalid argument for flag `--t'") {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+
+	// Call ParseArgs again and verify that the error is still returned
+	_, err = parser.ParseArgs(nil)
+	if err == nil {
+		t.Fatal("parser did not return error for invalid env var on second call")
+	}
+	if !strings.Contains(err.Error(), "invalid argument for flag `--t'") {
+		t.Fatalf("unexpected error: %s", err.Error())
+	}
+
+}
+
 type CustomFlag struct {
 	Value string
 }


### PR DESCRIPTION
If you set an invalid flag value using an env var and then parse, it will correctly return an error. But the library also sets some state which means if you call parse again, the flag is not evaluated and no error is returned.

This caused an issue for us because we parse flags once to determine if the client has passed a directory containing additional flag values, and then parse again if so. We can't return errors after the first attempt because missing required flags are expected if the client has passed a directory containing additional flags. So we need the invalid value error to be returned again on the second parse attempt.

(see TM-84756)