### PR TITLE
Honour `choice` tag on positional arguments

### DIFF
--- a/arg.go
+++ b/arg.go
@@ -12,12 +12,18 @@ type Arg struct {
 	// A description of the positional argument (used in the help)
 	Description string
 
+	// If non-empty, only a certain set of values is allowed for the positional
+	// argument. This can only be enforced if the positional argument is not a
+	// slice type (i.e., it does not collect all remaining arguments).
+	Choices []string
+
 	// The minimal number of required positional arguments
 	Required int
 
 	// The maximum number of required positional arguments
 	RequiredMaximum int
 
+	field reflect.StructField
 	value reflect.Value
 	tag   multiTag
 }

--- a/arg_test.go
+++ b/arg_test.go
@@ -162,6 +162,72 @@ func TestPositionalRequiredRestRangeEmptyFail(t *testing.T) {
 	assertError(t, err, ErrRequired, "the required argument `Rest (zero arguments)` was not provided")
 }
 
+func TestPositionalChoiceRequiredPass(t *testing.T) {
+	var opts = struct {
+		Positional struct {
+			Command  int
+			Filename string `choice:"file1" choice:"file2"`
+		} `positional-args:"yes" required:"yes"`
+	}{}
+
+	p := NewParser(&opts, None)
+	_, err := p.ParseArgs([]string{"10", "file2"})
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+		return
+	}
+
+	assertString(t, opts.Positional.Filename, "file2")
+}
+
+func TestPositionalChoiceRequiredFail(t *testing.T) {
+	var opts = struct {
+		Positional struct {
+			Command  int
+			Filename string `choice:"file1" choice:"file2"`
+		} `positional-args:"yes" required:"yes"`
+	}{}
+
+	p := NewParser(&opts, None)
+	_, err := p.ParseArgs([]string{"10", "file3"})
+
+	assertError(t, err, ErrInvalidChoice, "Invalid value `file3' for argument `Filename'. Allowed values are: file1 or file2")
+}
+
+func TestPositionalChoiceOptionalPass(t *testing.T) {
+	var opts = struct {
+		Positional struct {
+			Command  int
+			Filename string `choice:"file1" choice:"file2"`
+		} `positional-args:"yes"`
+	}{}
+
+	p := NewParser(&opts, None)
+	_, err := p.ParseArgs([]string{"10", "file2"})
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+		return
+	}
+
+	assertString(t, opts.Positional.Filename, "file2")
+}
+
+func TestPositionalChoiceOptionalFail(t *testing.T) {
+	var opts = struct {
+		Positional struct {
+			Command  int
+			Filename string `choice:"file1" choice:"file2"`
+		} `positional-args:"yes"`
+	}{}
+
+	p := NewParser(&opts, None)
+	_, err := p.ParseArgs([]string{"10", "file3"})
+
+	assertError(t, err, ErrInvalidChoice, "Invalid value `file3' for argument `Filename'. Allowed values are: file1 or file2")
+}
+
 func TestPositionalWithSubcommand(t *testing.T) {
 	var opts = struct {
 		Command struct {

--- a/command.go
+++ b/command.go
@@ -208,9 +208,11 @@ func (c *Command) scanSubcommandHandler(parentg *Group) scanHandler {
 				arg := &Arg{
 					Name:            name,
 					Description:     m.Get("description"),
+					Choices:         m.GetMany("choice"),
 					Required:        required,
 					RequiredMaximum: requiredMaximum,
 
+					field: field,
 					value: realval.Field(i),
 					tag:   m,
 				}

--- a/completion.go
+++ b/completion.go
@@ -286,13 +286,21 @@ func (c *completion) complete(args []string) []Completion {
 	} else if len(s.command.commands) > 0 {
 		// Complete for command
 		ret = c.completeCommands(s, lastarg)
-		if len(ret) == 0 && len(s.positional) > 0 {
+		if len(s.positional) > 0 {
 			// Complete for positional arguments if available
-			ret = c.completeValue(s.positional[0].value, nil, "", lastarg)
+			if len(s.positional[0].Choices) != 0 {
+				ret = append(ret, c.completeValue(s.positional[0].value, &s.positional[0].field, "", lastarg)...)
+			} else {
+				ret = append(ret, c.completeValue(s.positional[0].value, nil, "", lastarg)...)
+			}
 		}
 	} else if len(s.positional) > 0 {
 		// Complete for positional argument
-		ret = c.completeValue(s.positional[0].value, nil, "", lastarg)
+		if len(s.positional[0].Choices) != 0 {
+			ret = c.completeValue(s.positional[0].value, &s.positional[0].field, "", lastarg)
+		} else {
+			ret = c.completeValue(s.positional[0].value, nil, "", lastarg)
+		}
 	}
 
 	sort.Sort(completions(ret))

--- a/completion_test.go
+++ b/completion_test.go
@@ -76,6 +76,17 @@ var completionTestOptions struct {
 		Completed TestComplete `short:"c" long:"completed"`
 	} `command:"rename" description:"rename an item"`
 
+	ChoiceCommand struct {
+		Positional struct {
+			Choice string `choice:"pos-choice-1" choice:"pos-choice-2"`
+		} `positional-args:"yes"`
+		Subcommand struct {
+			Positional struct {
+				Choice string `choice:"pos-choice-sub-1" choice:"pos-choice-sub-2"`
+			} `positional-args:"yes"`
+		} `command:"sub"`
+	} `command:"choice" hidden:"true"`
+
 	HiddenCommand struct {
 	} `command:"hidden" description:"hidden command" hidden:"true"`
 }
@@ -205,6 +216,19 @@ func init() {
 		},
 
 		{
+			"Subcommand and positional with choice",
+			[]string{"choice", ""},
+			[]string{"pos-choice-1", "pos-choice-2", "sub"},
+			false,
+		},
+		{
+			"Positional with choice",
+			[]string{"choice", "sub", ""},
+			[]string{"pos-choice-sub-1", "pos-choice-sub-2"},
+			false,
+		},
+
+		{
 			"Flag filename",
 			[]string{"rm", "-f", path.Join(completionTestSourcedir, "completion")},
 			completionTestFilename,
@@ -275,7 +299,7 @@ func init() {
 		{
 			"Completion for subcommands",
 			[]string{"add", "mul"},
-			[]string{"multi"},
+			[]string{"multi", "multitag.go"},
 			false,
 		},
 		{

--- a/flags.go
+++ b/flags.go
@@ -108,8 +108,8 @@ The following is a list of tags for struct fields supported by go-flags:
                     slices and maps (optional)
     value-name:     the name of the argument value (to be shown in the help)
                     (optional)
-    choice:         limits the values for an option to a set of values.
-                    Repeat this tag once for each allowable value.
+    choice:         limits the values for an option or positional argument to a
+                    set of values. Repeat this tag once for each allowable value.
                     e.g. `long:"animal" choice:"cat" choice:"dog"`
     hidden:         if non-empty, the option is not visible in the help or man page.
 

--- a/parser.go
+++ b/parser.go
@@ -651,6 +651,30 @@ func (p *parseState) addArgs(args ...string) error {
 	for len(p.positional) > 0 && len(args) > 0 {
 		arg := p.positional[0]
 
+		if !arg.isRemaining() && len(arg.Choices) != 0 {
+			found := false
+
+			for _, choice := range arg.Choices {
+				if choice == args[0] {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				allowed := strings.Join(arg.Choices[0:len(arg.Choices)-1], ", ")
+
+				if len(arg.Choices) > 1 {
+					allowed += " or " + arg.Choices[len(arg.Choices)-1]
+				}
+
+				p.err = newErrorf(ErrInvalidChoice,
+					"Invalid value `%s' for argument `%s'. Allowed values are: %s",
+					args[0], arg.Name, allowed)
+				return p.err
+			}
+		}
+
 		if err := convert(args[0], arg.value, arg.tag); err != nil {
 			p.err = err
 			return err


### PR DESCRIPTION
If a positional argument has a non-slice type (i.e., if it represents a single argument rather than a collection of remaining arguments), allow the use of the `choice` tag to restrict the set of permitted values, as is already possible with options. Additionally, provide choices for positional arguments as command line completions in the appropriate context.